### PR TITLE
Add basic mobile UI layout with equipment screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+  <title>Tower Defense</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="top-bar">
+    <div id="resources">
+      <span id="gold">💰0</span>
+      <span id="diamond">💎0</span>
+      <span id="energy">⚡10/20</span>
+    </div>
+    <button id="options">⚙️</button>
+  </div>
+  <div id="main-content">
+    <section id="main-screen" class="screen">
+      <h1>타워 디펜스</h1>
+    </section>
+    <section id="equipment-screen" class="screen hidden">
+      <div id="equipment-top">
+        <div id="equipment-left" class="equipment-column">
+          <div class="slot">무기</div>
+          <div class="slot">탄약</div>
+          <div class="slot">조준경</div>
+        </div>
+        <div id="tower-view">🗼</div>
+        <div id="equipment-right" class="equipment-column">
+          <div class="slot">레이더</div>
+          <div class="slot">쉴드</div>
+          <div class="slot">발전소</div>
+        </div>
+      </div>
+      <div id="inventory"></div>
+    </section>
+  </div>
+  <nav id="bottom-bar">
+    <button data-screen="shop">상점</button>
+    <button data-screen="equipment">장비</button>
+    <button data-screen="stage">스테이지</button>
+    <button data-screen="skill">스킬</button>
+    <button data-screen="challenge">챌린지</button>
+  </nav>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,32 @@
+// Enter full screen on any click if not already full screen
+function requestFullScreen() {
+  if (!document.fullscreenElement && document.documentElement.requestFullscreen) {
+    document.documentElement.requestFullscreen().catch(() => {});
+  }
+}
+
+document.addEventListener('click', requestFullScreen);
+
+// Screen switching
+const screens = document.querySelectorAll('.screen');
+const inventory = document.getElementById('inventory');
+
+// Populate inventory with placeholder items
+for (let i = 1; i <= 30; i++) {
+  const item = document.createElement('div');
+  item.className = 'item';
+  item.textContent = i;
+  inventory.appendChild(item);
+}
+
+document.querySelectorAll('#bottom-bar button').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const screen = btn.getAttribute('data-screen');
+    screens.forEach(sec => sec.classList.add('hidden'));
+    if (screen === 'equipment') {
+      document.getElementById('equipment-screen').classList.remove('hidden');
+    } else {
+      document.getElementById('main-screen').classList.remove('hidden');
+    }
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,98 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: sans-serif;
+}
+
+#top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 5px 10px;
+}
+
+#resources span {
+  margin-right: 8px;
+}
+
+#options {
+  background: none;
+  border: none;
+  font-size: 20px;
+}
+
+#bottom-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  padding: 5px 0;
+  background: #eee;
+}
+
+#main-content {
+  padding-bottom: 60px; /* space for bottom bar */
+}
+
+.screen.hidden {
+  display: none;
+}
+
+#equipment-screen {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 60px - 40px); /* top and bottom bars */
+}
+
+#equipment-top {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 10px;
+}
+
+.equipment-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.slot {
+  width: 60px;
+  height: 60px;
+  border: 1px solid #ccc;
+  margin: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+}
+
+#tower-view {
+  width: 80px;
+  height: 120px;
+  margin: 5px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 40px;
+}
+
+#inventory {
+  flex: 1;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-auto-rows: 60px;
+  gap: 5px;
+  padding: 5px;
+}
+
+#inventory .item {
+  border: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary
- Build main UI for portrait mobile web game with top resource bar, options button, and bottom navigation
- Add equipment screen featuring tower view, equipment slots, and scrollable inventory grid
- Implement fullscreen toggle on first tap and basic screen switching logic

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68b27d217a5c8332a837ef9a261eab40