### PR TITLE
Add stage selection screen and clean inventory

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
   </div>
   <div id="main-content">
     <section id="main-screen" class="screen">
-      <h1>타워 디펜스</h1>
     </section>
     <section id="equipment-screen" class="screen hidden">
       <div id="equipment-top">
@@ -34,6 +33,19 @@
         </div>
       </div>
       <div id="inventory"></div>
+    </section>
+    <section id="stage-screen" class="screen hidden">
+      <div id="stage-header">
+        <button id="prev-stage">◀</button>
+        <h2 id="stage-number"></h2>
+        <button id="next-stage">▶</button>
+      </div>
+      <div id="stage-stars"></div>
+      <div id="stage-actions">
+        <button id="hunt-button">토벌</button>
+        <button id="challenge-button">도전</button>
+        <button id="reward-button">보상</button>
+      </div>
     </section>
   </div>
   <nav id="bottom-bar">

--- a/script.js
+++ b/script.js
@@ -11,13 +11,54 @@ document.addEventListener('click', requestFullScreen);
 const screens = document.querySelectorAll('.screen');
 const inventory = document.getElementById('inventory');
 
-// Populate inventory with placeholder items
-for (let i = 1; i <= 30; i++) {
+// Populate inventory with actual items (no empty slots or numbering)
+const items = ['🗡️', '🛡️', '🎯'];
+items.forEach(icon => {
   const item = document.createElement('div');
   item.className = 'item';
-  item.textContent = i;
+  item.textContent = icon;
   inventory.appendChild(item);
+});
+
+// Stage selection data and helpers
+const stages = [
+  { number: 1, hp: null },
+  { number: 2, hp: 40 },
+  { number: 3, hp: 80 },
+  { number: 4, hp: 96 }
+];
+let currentStage = 0;
+const stageNumberEl = document.getElementById('stage-number');
+const stageStarsEl = document.getElementById('stage-stars');
+
+function stageStars(hp) {
+  if (hp == null) return '☆☆☆';
+  if (hp < 50) return '★☆☆';
+  if (hp < 95) return '★★☆';
+  return '★★★';
 }
+
+function updateStage() {
+  const stage = stages[currentStage];
+  stageNumberEl.textContent = `스테이지 ${stage.number}`;
+  stageStarsEl.textContent = stageStars(stage.hp);
+}
+
+document.getElementById('prev-stage').addEventListener('click', () => {
+  if (currentStage > 0) {
+    currentStage--;
+    updateStage();
+  }
+});
+
+document.getElementById('next-stage').addEventListener('click', () => {
+  if (currentStage < stages.length - 1) {
+    currentStage++;
+    updateStage();
+  }
+});
+
+updateStage();
 
 document.querySelectorAll('#bottom-bar button').forEach(btn => {
   btn.addEventListener('click', () => {
@@ -25,6 +66,8 @@ document.querySelectorAll('#bottom-bar button').forEach(btn => {
     screens.forEach(sec => sec.classList.add('hidden'));
     if (screen === 'equipment') {
       document.getElementById('equipment-screen').classList.remove('hidden');
+    } else if (screen === 'stage') {
+      document.getElementById('stage-screen').classList.remove('hidden');
     } else {
       document.getElementById('main-screen').classList.remove('hidden');
     }

--- a/style.css
+++ b/style.css
@@ -96,3 +96,32 @@ html, body {
   align-items: center;
   justify-content: center;
 }
+
+#stage-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: calc(100vh - 60px - 40px);
+}
+
+#stage-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+#stage-stars {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+}
+
+#stage-actions {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 20px;
+}


### PR DESCRIPTION
## Summary
- Remove top "타워 디펜스" heading
- Hide empty inventory slots and numbering
- Introduce stage selection screen with star ratings and action buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cef153f08332af795123f2069b02