### PR TITLE
Lock stages until cleared and fit UI on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,11 +30,13 @@ const stages = [
 let currentStage = 0;
 const stageNumberEl = document.getElementById('stage-number');
 const stageStarsEl = document.getElementById('stage-stars');
+const prevStageBtn = document.getElementById('prev-stage');
+const nextStageBtn = document.getElementById('next-stage');
 
 function stageStars(hp) {
-  if (hp == null) return '☆☆☆';
-  if (hp < 50) return '★☆☆';
-  if (hp < 95) return '★★☆';
+  if (hp == null) return '';
+  if (hp < 50) return '★';
+  if (hp < 95) return '★★';
   return '★★★';
 }
 
@@ -42,17 +44,19 @@ function updateStage() {
   const stage = stages[currentStage];
   stageNumberEl.textContent = `스테이지 ${stage.number}`;
   stageStarsEl.textContent = stageStars(stage.hp);
+  prevStageBtn.disabled = currentStage === 0;
+  nextStageBtn.disabled = currentStage === stages.length - 1 || stage.hp === null;
 }
 
-document.getElementById('prev-stage').addEventListener('click', () => {
+prevStageBtn.addEventListener('click', () => {
   if (currentStage > 0) {
     currentStage--;
     updateStage();
   }
 });
 
-document.getElementById('next-stage').addEventListener('click', () => {
-  if (currentStage < stages.length - 1) {
+nextStageBtn.addEventListener('click', () => {
+  if (currentStage < stages.length - 1 && stages[currentStage].hp !== null) {
     currentStage++;
     updateStage();
   }

--- a/style.css
+++ b/style.css
@@ -1,15 +1,26 @@
+* {
+  box-sizing: border-box;
+}
+
 html, body {
   margin: 0;
   padding: 0;
   height: 100%;
   font-family: sans-serif;
+  overflow: hidden;
 }
 
 #top-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 50px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 5px 10px;
+  background: #fff;
 }
 
 #resources span {
@@ -27,14 +38,21 @@ html, body {
   bottom: 0;
   left: 0;
   right: 0;
+  height: 50px;
   display: flex;
   justify-content: space-around;
+  align-items: center;
   padding: 5px 0;
   background: #eee;
 }
 
 #main-content {
-  padding-bottom: 60px; /* space for bottom bar */
+  position: absolute;
+  top: 50px;
+  bottom: 50px;
+  left: 0;
+  right: 0;
+  overflow: hidden;
 }
 
 .screen.hidden {
@@ -44,7 +62,7 @@ html, body {
 #equipment-screen {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 60px - 40px); /* top and bottom bars */
+  height: 100%;
 }
 
 #equipment-top {
@@ -101,7 +119,7 @@ html, body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: calc(100vh - 60px - 40px);
+  height: 100%;
 }
 
 #stage-header {


### PR DESCRIPTION
## Summary
- Fix top and bottom bars so the game fits in a mobile vertical screen without scrolling
- Display star scores based on clear HP and block moving to or challenging locked stages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baf9fecfa883328ebe73fd1f540172