### PR TITLE
Add stage action button handlers

### DIFF
--- a/script.js
+++ b/script.js
@@ -64,6 +64,20 @@ nextStageBtn.addEventListener('click', () => {
 
 updateStage();
 
+// Stage action buttons
+const huntButton = document.getElementById('hunt-button');
+const challengeButton = document.getElementById('challenge-button');
+const rewardButton = document.getElementById('reward-button');
+
+function handleStageAction(action) {
+  // Placeholder for stage progression logic such as energy deduction or screen change
+  alert(`${action} 기능은 준비 중입니다.`);
+}
+
+huntButton.addEventListener('click', () => handleStageAction('토벌'));
+challengeButton.addEventListener('click', () => handleStageAction('도전'));
+rewardButton.addEventListener('click', () => handleStageAction('보상'));
+
 const bottomBarButtons = document.querySelectorAll('#bottom-bar button');
 bottomBarButtons.forEach(btn => {
   btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Get stage action buttons in script.js
- Add click handlers with placeholder alerts and reusable function for stage actions

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfa8cefc08332bd8cd3c751b1afbe