### PR TITLE
Fix stage button click handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,7 +5,8 @@ function requestFullScreen() {
   }
 }
 
-document.addEventListener('click', requestFullScreen);
+// Request fullscreen only once to avoid stealing subsequent click events
+document.addEventListener('click', requestFullScreen, { once: true });
 
 // Screen switching
 const screens = document.querySelectorAll('.screen');


### PR DESCRIPTION
## Summary
- Request fullscreen only on first user interaction so click events like stage selection are not blocked

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bc0bfb15a883328de24543dc0034b0