### PR TITLE
Fix stage navigation unresponsive

### DIFF
--- a/script.js
+++ b/script.js
@@ -45,7 +45,7 @@ function updateStage() {
   stageNumberEl.textContent = `스테이지 ${stage.number}`;
   stageStarsEl.textContent = stageStars(stage.hp);
   prevStageBtn.disabled = currentStage === 0;
-  nextStageBtn.disabled = currentStage === stages.length - 1 || stage.hp === null;
+  nextStageBtn.disabled = currentStage === stages.length - 1;
 }
 
 prevStageBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Enable navigating between stages even if current stage lacks HP data

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18d8293288332b4f0d9a8885d0911