### PR TITLE
Fix screen switching by enforcing hidden class

### DIFF
--- a/style.css
+++ b/style.css
@@ -55,8 +55,8 @@ html, body {
   overflow: hidden;
 }
 
-.screen.hidden {
-  display: none;
+.hidden {
+  display: none !important;
 }
 
 #equipment-screen {


### PR DESCRIPTION
## Summary
- Ensure any element with `hidden` class is always hidden, overriding ID styles
- Prevent equipment screen from showing when navigating to other screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dc44664c8332b17c8201edd15b21