### PR TITLE
Fix stage navigation button lock logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -44,10 +44,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function updateStage() {
     const stage = stages[currentStage];
+    const nextStage = stages[currentStage + 1];
+
     stageNumberEl.textContent = `스테이지 ${stage.number}`;
     stageStarsEl.textContent = stageStars(stage.hp);
+
     prevStageBtn.disabled = currentStage === 0;
-    nextStageBtn.disabled = currentStage === stages.length - 1 || stage.hp === null;
+    nextStageBtn.disabled =
+      !nextStage || nextStage.hp === null;
   }
 
   prevStageBtn.addEventListener('click', () => {
@@ -58,7 +62,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   nextStageBtn.addEventListener('click', () => {
-    if (currentStage < stages.length - 1 && stages[currentStage].hp !== null) {
+    const nextStage = stages[currentStage + 1];
+    if (nextStage && nextStage.hp !== null) {
       currentStage++;
       updateStage();
     }


### PR DESCRIPTION
## Summary
- keep the next stage button enabled when a playable stage exists
- update the click handler to advance only when the next stage contains data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c936816acc8332aa9b53d2805b905f